### PR TITLE
Fix handling of URI errors.

### DIFF
--- a/discovery/repos/CentOS.py
+++ b/discovery/repos/CentOS.py
@@ -20,7 +20,9 @@ class CentOS(Repository):
   ####################################################################
   # Overridden methods
   ####################################################################
-  def _filterNonExistentArchitecture(self, repos, architecture):
+  def _filterRepos(self, repos, architecture):
+    repos = super(CentOS, self)._filterRepos(repos, architecture)
+
     regex = re.compile(r"(?i)<a\s+href=\"({0}/)\">\1</a>".format(architecture))
 
     return dict([ (key, value)

--- a/discovery/repos/Fedora.py
+++ b/discovery/repos/Fedora.py
@@ -38,7 +38,9 @@ class Fedora(Repository):
                     super(Fedora, self)._categoryReleased(architecture))
 
   ####################################################################
-  def _filterNonExistentArchitecture(self, repos, architecture):
+  def _filterRepos(self, repos, architecture):
+    repos = super(Fedora, self)._filterRepos(repos, architecture)
+
     repos = dict([ (key, value)
                       for (key, value) in repos.items()
                         if self._uri_contents(

--- a/discovery/repos/RHEL.py
+++ b/discovery/repos/RHEL.py
@@ -20,7 +20,9 @@ class RHEL(Repository):
   ####################################################################
   # Overridden methods
   ####################################################################
-  def _filterNonExistentArchitecture(self, repos, architecture):
+  def _filterRepos(self, repos, architecture):
+    repos = super(RHEL, self)._filterRepos(repos, architecture)
+
     regex = re.compile(r"(?i)<a\s+href=\"({0}/)\">\1</a>".format(architecture))
 
     return dict([ (key, value)

--- a/discovery/repos/Repository.py
+++ b/discovery/repos/Repository.py
@@ -138,7 +138,7 @@ class Repository(factory.Factory, defaults.DefaultsFileInfo):
     return self.__privateAvailableRoots(self._categoryLatest(architecture),
                                         architecture,
                                         functools.partial(
-                                          self. _filterNonExistentArchitecture,
+                                          self. _filterRepos,
                                           self._agnosticLatest(architecture),
                                           architecture))
 
@@ -147,7 +147,7 @@ class Repository(factory.Factory, defaults.DefaultsFileInfo):
     return self.__privateAvailableRoots(self._categoryNightly(architecture),
                                         architecture,
                                         functools.partial(
-                                          self. _filterNonExistentArchitecture,
+                                          self. _filterRepos,
                                           self._agnosticNightly(architecture),
                                           architecture))
 
@@ -156,7 +156,7 @@ class Repository(factory.Factory, defaults.DefaultsFileInfo):
     return self.__privateAvailableRoots(self._categoryReleased(architecture),
                                         architecture,
                                         functools.partial(
-                                          self. _filterNonExistentArchitecture,
+                                          self. _filterRepos,
                                           self._agnosticReleased(architecture),
                                           architecture))
 
@@ -214,11 +214,17 @@ class Repository(factory.Factory, defaults.DefaultsFileInfo):
     return argparse.Namespace(forceScan = False)
 
   ####################################################################
-  def _filterNonExistentArchitecture(self, repos, architecture):
+  def _filterRepos(self, repos, architecture = None):
     """Filters out the repos that don't have a subdir for the
     specified archtecture returning only those that do.
+
+    Subclasses need to override this to account for their unique
+    organization of repositories but must also call this first to
+    remove any contents that indicate an error in retrieval.
     """
-    raise NotImplementedError
+    repos = dict([ (key, value) for (key, value) in repos.items()
+                                if key != self.uriError ])
+    return repos
 
   ####################################################################
   def _findAgnosticLatestRoots(self, architecture):

--- a/python3-resource-discovery.spec
+++ b/python3-resource-discovery.spec
@@ -3,8 +3,8 @@
 %define repo_name python-support-resource-discovery
 %define repo_branch main
 
-%define version 1.0.12
-%define unmangled_version 1.0.12
+%define version 1.0.13
+%define unmangled_version 1.0.13
 %define release 1
 
 Name: python3-%{modname}
@@ -74,6 +74,9 @@ UNKNOWN
 %{python3_sitelib}/python3_resource_discovery-%{version}*
 
 %changelog
+* Thu Jul 06 2023 Joe Shimkus <jshimkus@redhat.com> - 1.0.13-1
+- Fixed handling of URI errors as input to repo filtering.
+
 * Fri Jun 09 2023 Joe Shimkus <jshimkus@redhat.com> - 1.0.12-1
 - Added an Architecture virtualization flag property.
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ except KeyError:
 setup = functools.partial(
           setuptools.setup,
           name = python_prefixed(package_name),
-          version = "1.0.12",
+          version = "1.0.13",
           description = python_prefixed(package_name),
           author = "Joe Shimkus",
           author_email = "jshimkus@redhat.com",


### PR DESCRIPTION
URI errors that were recorded into the repo cache files were not being appropriately handled.  This was happening for RHEL where the key (normally a distribution version such as "8.9") was being coerced to a float in checking if the particular version has support for a specified architecture.  In the case of a URI recorded in the repo cache the contents were not a valid float resulting in an exception. The fix is to have the base class, Repository, filter out repo entries that indicate an URI error.  A subclass overriding the filter method must first invoke its superclass's filtering after which the subclass may assume any remaining repo entries are of the expected form.